### PR TITLE
Fixing str_length benchmark

### DIFF
--- a/tango-bench/benches/tango-faster.rs
+++ b/tango-bench/benches/tango-faster.rs
@@ -5,12 +5,12 @@ use std::process::ExitCode;
 use tango_bench::{
     benchmark_fn, benchmarks, cli, BenchmarkMatrix, IntoBenchmarks, MeasurementSettings,
 };
-use test_funcs::{sort_unstable, str_count, str_take, RandomString, RandomVec};
+use test_funcs::{sort_unstable, str_count, str_take, RandomSubstring, RandomVec};
 
 mod test_funcs;
 
 fn str_benchmarks() -> impl IntoBenchmarks {
-    BenchmarkMatrix::new(RandomString::new())
+    BenchmarkMatrix::new(RandomSubstring::new())
         .add_function("str_length", str_count)
         .add_function("str_length_limit", |h, n| str_take(4950, h, n))
 }

--- a/tango-bench/benches/tango-slower.rs
+++ b/tango-bench/benches/tango-slower.rs
@@ -5,12 +5,12 @@ use std::process::ExitCode;
 use tango_bench::{
     benchmark_fn, benchmarks, cli, BenchmarkMatrix, IntoBenchmarks, MeasurementSettings,
 };
-use test_funcs::{sort_stable, str_count_rev, str_take, RandomString, RandomVec};
+use test_funcs::{sort_stable, str_count_rev, str_take, RandomSubstring, RandomVec};
 
 mod test_funcs;
 
 fn str_benchmarks() -> impl IntoBenchmarks {
-    BenchmarkMatrix::new(RandomString::new())
+    BenchmarkMatrix::new(RandomSubstring::new())
         .add_function("str_length", str_count_rev)
         .add_function("str_length_limit", |h, n| str_take(5000, h, n))
 }

--- a/tango-bench/src/cli.rs
+++ b/tango-bench/src/cli.rs
@@ -344,7 +344,7 @@ pub mod reporting {
                 ""
             );
             println!(
-                "    {:12} │ {:>15} {:>15} {:>15}  {:+4.2}{}",
+                "    {:12} │ {:>15} {:>15} {:>15}  {:+4.2}{}{}",
                 "mean",
                 HumanTime(base.mean),
                 HumanTime(candidate.mean),
@@ -358,7 +358,8 @@ pub mod reporting {
                     significant,
                     results.diff.mean < 0.
                 ),
-                colorize("%", significant, results.diff.mean < 0.)
+                colorize("%", significant, results.diff.mean < 0.),
+                if significant { "*" } else { "" },
             );
             println!(
                 "    {:12} │ {:>15} {:>15} {:>15}",
@@ -399,12 +400,13 @@ pub mod reporting {
             let speedup = diff.mean / base.mean * 100.;
             let candidate_faster = diff.mean < 0.;
             println!(
-                "{:50} [ {:>8} ... {:>8} ]    {:>+7.2}{}",
+                "{:50} [ {:>8} ... {:>8} ]    {:>+7.2}{}{}",
                 colorize(&results.name, significant, candidate_faster),
                 HumanTime(base.mean),
                 colorize(HumanTime(candidate.mean), significant, candidate_faster),
                 colorize(speedup, significant, candidate_faster),
-                colorize("%", significant, candidate_faster)
+                colorize("%", significant, candidate_faster),
+                if significant { "*" } else { "" },
             )
         }
     }

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -156,14 +156,13 @@ where
     fn measure(&mut self, iterations: usize) -> u64 {
         let mut g = self.g.borrow_mut();
         let haystack = &*self.haystack.get_or_insert_with(|| g.next_haystack());
-        let mut needles = Vec::with_capacity(iterations);
-        g.next_needles(haystack, iterations, &mut needles);
 
         let f = self.f.borrow_mut();
         let mut result = Vec::with_capacity(iterations);
         let start = ActiveTimer::start();
-        for needle in &needles {
-            result.push(black_box((f)(haystack, needle)));
+        for _ in 0..iterations {
+            let needle = g.next_needle(&haystack);
+            result.push(black_box((f)(haystack, &needle)));
         }
         let time = ActiveTimer::stop(start);
         drop(result);


### PR DESCRIPTION
`str_length_limit/RandomString<50000>` benchmark is not stable from run to run. It was caused by haystack being new allocated `String` each time. Also moved needle generation inside timing loop. This drops the need of buffering needles for the whole sample minimizing CPU cache thrashing probability.