### PR TITLE
glob support added to -f

### DIFF
--- a/examples/benches/common.rs
+++ b/examples/benches/common.rs
@@ -35,9 +35,9 @@ where
     pub fn new(size: usize, value_dup_factor: usize) -> Self {
         let type_name = type_name::<C::Item>();
         let name = if value_dup_factor > 1 {
-            format!("<{}, {}, dup-{}>", type_name, size, value_dup_factor)
+            format!("{}/{}/dup-{}", type_name, size, value_dup_factor)
         } else {
-            format!("<{}, {}>", type_name, size)
+            format!("{}/{}/nodup", type_name, size)
         };
 
         Self {

--- a/tango-bench/Cargo.toml
+++ b/tango-bench/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["benchmarks", "performance"]
 anyhow = "^1.0"
 clap = { version = "^4.4", features = ["derive"] }
 colorz = { version = "^1.1", features = ["supports-color"] }
+glob-match = "^0.2"
 libloading = "^0.8"
 num-traits = "^0.2"
 rand = { version = "^0.8", features = ["small_rng"] }

--- a/tango-bench/src/cli.rs
+++ b/tango-bench/src/cli.rs
@@ -6,6 +6,7 @@ use anyhow::Context;
 use clap::Parser;
 use colorz::mode::{self, Mode};
 use core::fmt;
+use glob_match::glob_match;
 use libloading::Library;
 use rand::{rngs::SmallRng, SeedableRng};
 use std::{
@@ -137,7 +138,7 @@ pub fn run(settings: MeasurementSettings) -> Result<ExitCode> {
             let mut rng = SmallRng::from_entropy();
             let filter = filter.as_deref().unwrap_or("");
             for func in spi_self.tests() {
-                if !func.name.contains(filter) || spi_lib.lookup(&func.name).is_none() {
+                if !glob_match(filter, &func.name) || spi_lib.lookup(&func.name).is_none() {
                     continue;
                 }
                 let diff = commands::paired_compare(

--- a/tango-bench/src/generators.rs
+++ b/tango-bench/src/generators.rs
@@ -13,7 +13,7 @@ impl<T> RandomVec<T> {
             SmallRng::seed_from_u64(42),
             size,
             PhantomData,
-            format!("RandomVec<{}, {}>", type_name::<T>(), size),
+            format!("{}/{}", type_name::<T>(), size),
         )
     }
 }


### PR DESCRIPTION
- `glob-match` crate added
- `-f` now supports glob pattern (it should fully describe test name)