### PR TITLE
Fixing issues found by ordsearch benchmark

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -34,7 +34,7 @@ jobs:
 
           mkdir -p target/dumps
           target/benchmarks/search_ord --color=never compare target/benchmarks/search_ord \
-            -t 1 -d target/dumps | tee target/benchmark.txt
+            -t 1 -o -d target/dumps | tee target/benchmark.txt
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -34,7 +34,7 @@ jobs:
 
           mkdir -p target/dumps
           target/benchmarks/search_ord --color=never compare target/benchmarks/search_ord \
-            -t 3 --fail-threshold 10 -d target/dumps | tee target/benchmark.txt
+            -t 1 -d target/dumps | tee target/benchmark.txt
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -34,7 +34,7 @@ jobs:
 
           mkdir -p target/dumps
           target/benchmarks/search_ord --color=never compare target/benchmarks/search_ord \
-            -t 2 --fail-threshold 10 -d target/dumps --dump-only-significant | tee target/benchmark.txt
+            -t 3 --fail-threshold 10 -d target/dumps | tee target/benchmark.txt
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -3,37 +3,39 @@ name: Benchmarks
 on: workflow_dispatch
 
 jobs:
-  build:
+  bench:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Rust
-        run: rustup update stable && rustup default stable
-      - name: Install Cargo Export
-        run: cargo install cargo-export
+      - name: Prepare Environment
+        run: |
+          rustup update stable
+          rustup default stable
+          cargo install cargo-export --version 0.2.0
 
-      - name: Restore ./target
-        uses: actions/cache@v3
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
-          key: Cargo/${{ runner.os }}
+            ./target/
+            ./baseline-branch/target/
+          key: Bench/${{ runner.os }}
 
-      - name: Run Tango Benchmarks
-        run: ./scripts/tango.sh
+      - name: Building Benchmarks
+        run: cargo export target/benchmarks -- bench --bench='search-*'
 
-      - name: Run Criterion Benchmarks
-        run: ./scripts/criterion.sh
+      - name: Run Benchmarks
+        run: |
+          set -eo pipefail
 
-      - name: Archive Benchmarks Results
-        uses: actions/upload-artifact@v3
+          target/benchmarks/search_ord --color=never compare target/benchmarks/search_ord \
+            -v -t 1 --fail-threshold 10 | tee target/benchmark.txt
+
+      - uses: actions/upload-artifact@v3
         with:
-          name: benchmarks.zip
-          path: |
-            target/tango.txt
-            target/criterion.txt
+          name: benchmark.txt
+          path: target/benchmark.txt

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -10,8 +10,8 @@ jobs:
 
       - name: Prepare Environment
         run: |
-          rustup update stable
-          rustup default stable
+          rustup update nightly
+          rustup default nightly
           cargo install cargo-export --version 0.2.0
 
       - uses: actions/cache@v3

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -26,7 +26,7 @@ jobs:
           key: Bench/${{ runner.os }}
 
       - name: Building Benchmarks
-        run: cargo export target/benchmarks -- bench --bench='search-*'
+        run: cargo export target/benchmarks -- bench --bench='search-*' --features=align
 
       - name: Run Benchmarks
         run: |
@@ -34,7 +34,7 @@ jobs:
 
           mkdir -p target/dumps
           target/benchmarks/search_ord --color=never compare target/benchmarks/search_ord \
-            -t 1 -d target/dumps | tee target/benchmark.txt
+            -t 0.5 -d target/dumps | tee target/benchmark.txt
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -35,6 +35,8 @@ jobs:
           mkdir -p target/dumps
           target/benchmarks/search_ord --color=never compare target/benchmarks/search_ord \
             -t 0.5 -d target/dumps | tee target/benchmark.txt
+          target/benchmarks/search_ord --color=never compare target/benchmarks/search_ord \
+            -t 0.5 -d target/dumps | tee -a target/benchmark.txt
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -26,7 +26,7 @@ jobs:
           key: Bench/${{ runner.os }}
 
       - name: Building Benchmarks
-        run: cargo export target/benchmarks -- bench --bench='search-*' --features=align
+        run: cargo export target/benchmarks -- bench --bench='search-*'
 
       - name: Run Benchmarks
         run: |
@@ -34,9 +34,7 @@ jobs:
 
           mkdir -p target/dumps
           target/benchmarks/search_ord --color=never compare target/benchmarks/search_ord \
-            -t 0.5 -d target/dumps | tee target/benchmark.txt
-          target/benchmarks/search_ord --color=never compare target/benchmarks/search_ord \
-            -t 0.5 -d target/dumps | tee -a target/benchmark.txt
+            -t 1 -d target/dumps | tee target/benchmark.txt
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -32,10 +32,13 @@ jobs:
         run: |
           set -eo pipefail
 
+          mkdir -p target/dumps
           target/benchmarks/search_ord --color=never compare target/benchmarks/search_ord \
-            -t 1 --fail-threshold 10 | tee target/benchmark.txt
+            -t 1 --fail-threshold 10 -d target/dumps --dump-only-significant | tee target/benchmark.txt
 
       - uses: actions/upload-artifact@v3
         with:
           name: benchmark.txt
-          path: target/benchmark.txt
+          path: |
+            target/benchmark.txt
+            target/dumps/*.csv

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -33,7 +33,7 @@ jobs:
           set -eo pipefail
 
           target/benchmarks/search_ord --color=never compare target/benchmarks/search_ord \
-            -v -t 1 --fail-threshold 10 | tee target/benchmark.txt
+            -t 1 --fail-threshold 10 | tee target/benchmark.txt
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -26,7 +26,7 @@ jobs:
           key: Bench/${{ runner.os }}
 
       - name: Building Benchmarks
-        run: cargo export target/benchmarks -- bench --bench='search-*'
+        run: cargo export target/benchmarks -- bench --bench='search-*' --features=hw_timer
 
       - name: Run Benchmarks
         run: |
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: benchmark.txt
+          name: benchmark-results
           path: |
             target/benchmark.txt
             target/dumps/*.csv

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -26,7 +26,7 @@ jobs:
           key: Bench/${{ runner.os }}
 
       - name: Building Benchmarks
-        run: cargo export target/benchmarks -- bench --bench='search-*' --features=hw_timer
+        run: cargo export target/benchmarks -- bench --bench='search-*'
 
       - name: Run Benchmarks
         run: |
@@ -34,7 +34,7 @@ jobs:
 
           mkdir -p target/dumps
           target/benchmarks/search_ord --color=never compare target/benchmarks/search_ord \
-            -t 1 --fail-threshold 10 -d target/dumps --dump-only-significant | tee target/benchmark.txt
+            -t 2 --fail-threshold 10 -d target/dumps --dump-only-significant | tee target/benchmark.txt
 
       - uses: actions/upload-artifact@v3
         with:

--- a/examples/benches/common.rs
+++ b/examples/benches/common.rs
@@ -132,7 +132,7 @@ where
 }
 
 pub const SETTINGS: MeasurementSettings = MeasurementSettings {
-    samples_per_haystack: 1_000_000,
+    samples_per_haystack: 50,
     max_iterations_per_sample: 10_000,
     ..DEFAULT_SETTINGS
 };

--- a/tango-bench/src/cli.rs
+++ b/tango-bench/src/cli.rs
@@ -132,9 +132,6 @@ pub fn run(settings: MeasurementSettings) -> Result<ExitCode> {
             #[cfg(target_os = "linux")]
             let path = crate::linux::patch_pie_binary_if_needed(&path)?.unwrap_or(path);
 
-            let lib = unsafe { Library::new(&path) }
-                .with_context(|| format!("Unable to open library: {}", path.display()))?;
-            let spi_lib = Spi::for_library(&lib)?;
             let spi_self = Spi::for_self().ok_or(Error::SpiSelfWasMoved)??;
 
             let mut settings = settings;
@@ -151,6 +148,10 @@ pub fn run(settings: MeasurementSettings) -> Result<ExitCode> {
             let mut rng = SmallRng::from_entropy();
             let filter = filter.as_deref().unwrap_or("");
             for func in spi_self.tests() {
+                let lib = unsafe { Library::new(&path) }
+                    .with_context(|| format!("Unable to open library: {}", path.display()))?;
+                let spi_lib = Spi::for_library(&lib)?;
+
                 if spi_lib.lookup(&func.name).is_none() {
                     continue;
                 }

--- a/tango-bench/src/cli.rs
+++ b/tango-bench/src/cli.rs
@@ -148,17 +148,18 @@ pub fn run(settings: MeasurementSettings) -> Result<ExitCode> {
             let mut rng = SmallRng::from_entropy();
             let filter = filter.as_deref().unwrap_or("");
             for func in spi_self.tests() {
-                let lib = unsafe { Library::new(&path) }
-                    .with_context(|| format!("Unable to open library: {}", path.display()))?;
-                let spi_lib = Spi::for_library(&lib)?;
-
-                if spi_lib.lookup(&func.name).is_none() {
-                    continue;
-                }
                 if !filter.is_empty() && !glob_match(filter, &func.name) {
                     continue;
                 }
+
                 for _ in 0..10 {
+                    let lib = unsafe { Library::new(&path) }
+                        .with_context(|| format!("Unable to open library: {}", path.display()))?;
+                    let spi_lib = Spi::for_library(&lib)?;
+                    if spi_lib.lookup(&func.name).is_none() {
+                        continue;
+                    }
+
                     let result = commands::paired_compare(
                         &spi_lib,
                         &spi_self,

--- a/tango-bench/src/cli.rs
+++ b/tango-bench/src/cli.rs
@@ -157,7 +157,7 @@ pub fn run(settings: MeasurementSettings) -> Result<ExitCode> {
                 if !filter.is_empty() && !glob_match(filter, &func.name) {
                     continue;
                 }
-                loop {
+                for _ in 0..10 {
                     let result = commands::paired_compare(
                         &spi_lib,
                         &spi_self,

--- a/tango-bench/src/cli.rs
+++ b/tango-bench/src/cli.rs
@@ -41,6 +41,10 @@ enum BenchmarkMode {
         #[arg(long = "dump-only-significant", default_value_t = false)]
         dump_only_significant: bool,
 
+        /// seed for the random number generator or omit to use a random seed
+        #[arg(long = "seed")]
+        seed: Option<u64>,
+
         #[arg(short = 's', long = "samples")]
         samples: Option<NonZeroUsize>,
 
@@ -117,6 +121,7 @@ pub fn run(settings: MeasurementSettings) -> Result<ExitCode> {
             path_to_dump,
             fail_threshold,
             significant_only,
+            seed,
             dump_only_significant,
         } => {
             let mut reporter: Box<dyn Reporter> = if verbose {
@@ -145,7 +150,10 @@ pub fn run(settings: MeasurementSettings) -> Result<ExitCode> {
 
             settings.filter_outliers = filter_outliers;
 
-            let mut rng = SmallRng::from_entropy();
+            let mut rng = seed
+                .map(SmallRng::seed_from_u64)
+                .unwrap_or_else(SmallRng::from_entropy);
+
             let filter = filter.as_deref().unwrap_or("");
             for func in spi_self.tests() {
                 if !filter.is_empty() && !glob_match(filter, &func.name) {

--- a/tango-bench/src/cli.rs
+++ b/tango-bench/src/cli.rs
@@ -228,6 +228,7 @@ mod commands {
     use crate::{calculate_run_result, RunResult};
     use std::{
         fs::File,
+        hint::black_box,
         io::{self, BufWriter, Write as _},
         path::Path,
         time::Instant,
@@ -284,11 +285,13 @@ mod commands {
         let start_time = Instant::now();
 
         let mut i = 0;
+        let mut cache_firewall = vec![0u8; 1024 * 1024];
         while loop_mode.should_continue(i, start_time) {
             i += 1;
             if i % settings.samples_per_haystack == 0 {
                 a.next_haystack(a_func);
                 b.next_haystack(b_func);
+                rng.fill_bytes(black_box(&mut cache_firewall));
             }
 
             // !!! IMPORTANT !!!
@@ -338,6 +341,7 @@ mod commands {
             }
         }
 
+        drop(cache_firewall);
         Ok(run_result)
     }
 

--- a/tango-bench/src/cli.rs
+++ b/tango-bench/src/cli.rs
@@ -174,7 +174,7 @@ pub fn run(settings: MeasurementSettings) -> Result<ExitCode> {
                     }
 
                     let speedup = result.diff.mean / result.baseline.mean * 100.;
-                    if speedup.abs() > 5. {
+                    if speedup.abs() > 2. {
                         continue;
                     }
 


### PR DESCRIPTION
- `--seed` option allows to set seed for random number generator
- outlier filtering was not working when Q1/Q3 was equal
- new way of function exchanging between iterations based on `mem::spaw()` is implemented