### PR TITLE
FFI isolate

### DIFF
--- a/examples/benches/criterion.rs
+++ b/examples/benches/criterion.rs
@@ -6,12 +6,6 @@ use test_funcs::{factorial, str_take, sum, RandomSubstring};
 
 mod test_funcs;
 
-/// Because benchmarks are builded with linker flag -rdynamic there should be dummy library entrypoint defined
-/// in all benchmarks. This is only needed when two benchmarks harnesses are used in a single crate.
-mod dummy_entrypoint {
-    tango_bench::tango_benchmarks!([]);
-}
-
 fn sum_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("arithmetic");
 

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -86,7 +86,10 @@ macro_rules! tango_benchmarks {
 /// This macro generate `main()` function for the benchmark harness. Can be used in a form with providing
 /// measurement settings:
 /// ```rust
-/// use tango_bench::{tango_main, MeasurementSettings};
+/// use tango_bench::{tango_main, tango_benchmarks, MeasurementSettings};
+///
+/// // Register benchmarks
+/// tango_benchmarks!([]);
 ///
 /// tango_main!(MeasurementSettings {
 ///     samples_per_haystack: 1000,

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -61,11 +61,22 @@ pub enum Error {
 #[macro_export]
 macro_rules! tango_benchmarks {
     ($($func_expr:expr),+) => {
+
+        /// Type checking tango_init() function
+        const TANGO_INIT: $crate::dylib::ffi::InitFn = tango_init;
+
+        /// Exported function for initializing the benchmark harness
         #[no_mangle]
-        pub fn __tango_create_benchmarks() -> Vec<Box<dyn $crate::MeasureTarget>> {
-            let mut benchmarks = vec![];
-            $(benchmarks.extend($crate::IntoBenchmarks::into_benchmarks($func_expr));)*
-            benchmarks
+        unsafe extern "C" fn tango_init() {
+            use $crate::dylib::{ffi::STATE, State};
+            if STATE.is_none() {
+                let mut benchmarks = vec![];
+                $(benchmarks.extend($crate::IntoBenchmarks::into_benchmarks($func_expr));)*
+                STATE = Some(State {
+                    benchmarks,
+                    selected_function: 0,
+                });
+            }
         }
     };
 }
@@ -88,6 +99,8 @@ macro_rules! tango_benchmarks {
 macro_rules! tango_main {
     ($settings:expr) => {
         fn main() -> $crate::cli::Result<std::process::ExitCode> {
+            // Initialize Tango for SelfVTable usage
+            unsafe { tango_init() };
             $crate::cli::run($settings)
         }
     };


### PR DESCRIPTION
This PR makes it possible to get rid of dummy entrypoints in non tango benchmark executables. `tango_init()` FFI function is moved to the client module and then it is called from `tango_main!()` to initialize tango properly in executable mode.