### PR TITLE
Cpu cache firewall

### DIFF
--- a/tango-bench/Cargo.toml
+++ b/tango-bench/Cargo.toml
@@ -29,7 +29,7 @@ tempfile = "3.8"
 
 [features]
 align = []
-hw_timer = []
+hw-timer = []
 
 [[bench]]
 name = "tango"

--- a/tango-bench/Cargo.toml
+++ b/tango-bench/Cargo.toml
@@ -30,6 +30,7 @@ tempfile = "3.8"
 [features]
 align = []
 hw-timer = []
+cache-firewall = []
 
 [[bench]]
 name = "tango"

--- a/tango-bench/src/cli.rs
+++ b/tango-bench/src/cli.rs
@@ -282,6 +282,18 @@ mod commands {
         }
     }
 
+    /// Spoiling the CPU cache with random data
+    ///
+    /// This functions tries to spoil the CPU cache with random data right after new haystack is generated,
+    /// so that both functions are tested on the same cache state.
+    #[cfg(feature = "cache-firewall")]
+    fn cpu_cache_firewall() {
+        use std::hint::black_box;
+        let mut buf = black_box(vec![0u8; 1024 * 512]);
+        rand::thread_rng().fill_bytes(&mut buf);
+        let _sum = buf.iter().fold(0u32, |a, b| a.wrapping_add(*b as u32));
+    }
+
     /// Measure the difference in performance of two functions
     ///
     /// Provides a way to save a raw dump of measurements into directory
@@ -377,6 +389,8 @@ mod commands {
                 if i % self.settings.samples_per_haystack == 0 {
                     a_func.next_haystack();
                     b_func.next_haystack();
+                    #[cfg(feature = "cache-firewall")]
+                    cpu_cache_firewall();
                 }
 
                 a_func.run(iterations);

--- a/tango-bench/src/cli.rs
+++ b/tango-bench/src/cli.rs
@@ -360,10 +360,6 @@ mod commands {
             while self.loop_mode.should_continue(i, start_time) {
                 let iterations = sampler.next_sample_iterations(i);
                 i += 1;
-                if i % self.settings.samples_per_haystack == 0 {
-                    a_func.next_haystack();
-                    b_func.next_haystack();
-                }
 
                 // !!! IMPORTANT !!!
                 // Algorithms should be called in different order on each new iteration.
@@ -376,6 +372,11 @@ mod commands {
                 {
                     mem::swap(&mut a_func, &mut b_func);
                     switch_counter += 1;
+                }
+
+                if i % self.settings.samples_per_haystack == 0 {
+                    a_func.next_haystack();
+                    b_func.next_haystack();
                 }
 
                 a_func.run(iterations);

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -847,10 +847,10 @@ pub fn iqr_variance_thresholds(mut input: Vec<f64>) -> Option<RangeInclusive<f64
 mod timer {
     use std::time::Instant;
 
-    #[cfg(all(feature = "hw_timer", target_arch = "x86_64"))]
+    #[cfg(all(feature = "hw-timer", target_arch = "x86_64"))]
     pub(super) type ActiveTimer = x86::RdtscpTimer;
 
-    #[cfg(not(feature = "hw_timer"))]
+    #[cfg(not(feature = "hw-timer"))]
     pub(super) type ActiveTimer = PlatformTimer;
 
     pub(super) trait Timer<T> {
@@ -872,7 +872,7 @@ mod timer {
         }
     }
 
-    #[cfg(all(feature = "hw_timer", target_arch = "x86_64"))]
+    #[cfg(all(feature = "hw-timer", target_arch = "x86_64"))]
     pub(super) mod x86 {
         use super::Timer;
         use std::arch::x86_64::{__rdtscp, _mm_mfence};


### PR DESCRIPTION
This PR adds a barrier that spoils CPU cache with random data. This is needed for both functions experience the same CPU cache state after haystack generation.