### PR TITLE
Fail fast option added

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ There are several arguments you can pass to the `compare` command to change it b
   - `-f` – filter benchmarks by name. Glob patterns are supported (eg. `*/bench_name/{2,4,8}/**`)
   - `o`, `--filter-outliers` – additionally filter outliers
   - `--fail-threshold` – do fail if new version is slower than baseline on a given percentage
+  - `--fail-fast` - do fail after first benchmark exceeding fail threshold, not after the whole suite
 
 ## Contributing
 


### PR DESCRIPTION
Now `--fail-threshold` fails not after the individual bench, but after the whole suite. I believe this is reasonable default, because this option is intended to be used inside CI environment.

For backward compatibility `--fail-fast` option added which stop benchmarking after individual benchmark.