### PR TITLE
Estimate improvement

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-tango-bench = { path="../tango-bench" }
+tango-bench = { path = "../tango-bench" }
 rand = { version = "0.8", features = ["small_rng"] }
 
 [dev-dependencies]
 criterion = "0.5.1"
-ordsearch = { version = "0.2.5", features = ["nightly"] }
+ordsearch = { version = "0.2.5" }
 num-traits = "0.2"
 
 [[bench]]

--- a/examples/benches/common.rs
+++ b/examples/benches/common.rs
@@ -8,7 +8,7 @@ use tango_bench::{
 };
 
 const SIZES: [usize; 14] = [
-    8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4069, 8192, 16384, 32768, 65536,
+    8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536,
 ];
 
 struct Lcg(usize);
@@ -61,6 +61,7 @@ where
     fn next_haystack(&mut self) -> Self::Haystack {
         let vec = generate_sorted_vec(self.size, self.value_dup_factor);
         let max = usize::try_from(*vec.last().unwrap()).ok().unwrap();
+
         Sample {
             collection: C::from_sorted_vec(vec),
             max_value: max,

--- a/examples/benches/common.rs
+++ b/examples/benches/common.rs
@@ -133,7 +133,7 @@ where
 }
 
 pub const SETTINGS: MeasurementSettings = MeasurementSettings {
-    samples_per_haystack: 50,
+    samples_per_haystack: usize::max_value(),
     max_iterations_per_sample: 10_000,
     ..DEFAULT_SETTINGS
 };

--- a/tango-bench/src/cli.rs
+++ b/tango-bench/src/cli.rs
@@ -265,9 +265,9 @@ impl LoopMode {
             LoopMode::Samples(samples) => iter_no < *samples,
             LoopMode::Time(duration) => {
                 // Trying not to stress benchmarking loop with to much of clock calls and check deadline
-                // approximately each 8 milliseconds based on the number of iterations already performed
-                // (we're assuming each iteration is approximately 1 ms)
-                if (iter_no & 0b111) == 0 {
+                // approximately each 200 milliseconds based on the number of iterations already performed
+                // (we're assuming each iteration is not longer than approximately 50 ms)
+                if (iter_no & 0b11) == 0 {
                     Instant::now() < (start_time + *duration)
                 } else {
                     true
@@ -382,6 +382,7 @@ mod commands {
         }
 
         pub fn run(&self, test_name: &str) -> Result<RunResult> {
+            const TIME_SLICE: u32 = 50;
             let a_func = self
                 .baseline
                 .lookup(test_name)
@@ -399,12 +400,13 @@ mod commands {
             a_func.sync(seed);
             b_func.sync(seed);
 
-            let iterations_per_sample =
-                b_func.estimate_iterations(50) / 2 + a_func.estimate_iterations(50) / 2;
+            let a_estimate = (a_func.estimate_iterations(TIME_SLICE) / 2).max(1);
+            let b_estimate = (b_func.estimate_iterations(TIME_SLICE) / 2).max(1);
+            let iterations_per_sample = a_estimate.min(b_estimate);
             let mut sampler = create_sampler(&self.settings, iterations_per_sample, seed);
 
-            // Synchronizing test functions one more time because estimation proces may perform different number of iterations
-            // on the functions thus running them out of sync.
+            // Synchronizing test functions one more time because the estimation process may perform a different
+            // number of iterations on the functions, thus running them out of sync.
             a_func.sync(seed);
             b_func.sync(seed);
 

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -485,6 +485,7 @@ pub struct MeasurementSettings {
 
     pub sampler_type: SamplerType,
 
+    /// If true scheduler performs warmup iterations before measuring function
     pub warmup_enabled: bool,
 
     /// Size of a CPU cache firewall in KBytes

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -360,11 +360,12 @@ impl<G: Generator> BenchmarkMatrix<G> {
 
 impl<G> IntoBenchmarks for BenchmarkMatrix<G> {
     fn into_benchmarks(self) -> Vec<Box<dyn MeasureTarget>> {
-        assert!(!self.functions.is_empty(), "No functions was given");
+        assert!(!self.functions.is_empty(), "No functions were given");
         self.functions
     }
 }
 
+/// Converts the implementing type into a vector of `MeasureTarget`.
 pub trait IntoBenchmarks {
     fn into_benchmarks(self) -> Vec<Box<dyn MeasureTarget>>;
 }

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -485,6 +485,8 @@ pub struct MeasurementSettings {
 
     pub sampler_type: SamplerType,
 
+    pub warmup_enabled: bool,
+
     /// Size of a CPU cache firewall in KBytes
     ///
     /// If set, the scheduler will perform a dummy data read between samples generation to spoil the CPU cache
@@ -542,6 +544,7 @@ pub const DEFAULT_SETTINGS: MeasurementSettings = MeasurementSettings {
     sampler_type: SamplerType::Random,
     cache_firewall: None,
     yield_before_sample: false,
+    warmup_enabled: true,
 };
 
 impl Default for MeasurementSettings {

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -752,7 +752,9 @@ impl DiffEstimate {
 
         // significant result is far away from 0 and have more than 0.5% base/candidate difference
         // z_score = 2.6 corresponds to 99% significance level
-        let significant = z_score.abs() >= 2.6 && (diff.mean / baseline.mean).abs() > 0.005;
+        let significant = z_score.abs() >= 2.6
+            && (diff.mean / baseline.mean).abs() > 0.005
+            && diff.mean.abs() >= ActiveTimer::precision() as f64;
         let pct = diff.mean / baseline.mean * 100.0;
 
         Self { pct, significant }
@@ -924,6 +926,13 @@ mod timer {
     pub(super) trait Timer<T> {
         fn start() -> T;
         fn stop(start_time: T) -> u64;
+
+        /// Timer precision in nanoseconds
+        ///
+        /// The results less than the precision of a timer are considered not significant
+        fn precision() -> u64 {
+            1
+        }
     }
 
     pub(super) struct PlatformTimer;


### PR DESCRIPTION
This PR adds following changes:

- there was asymmetry in benchmark haystack generation which favors one of the functions
- benchmarks seeds are now synchronized after estimation process to guarantee equivalent PRNG state in both functions
- time slice changed to 10ms
- new iteration count estimation process adaptively changes the number of iterations to guarantee 10ms per sample.
- warmup iterations are performed before each sample (1/10th of sample iterations). Can be disabled with `--warmup-enabled=false`
- `-t` option now take into consideration only tested function execution time. No additional timer overhead is required.
- timer precision added. If time difference between functions is less than absolute precision timer test results considered not significant