### PR TITLE
Async support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Cargo.lock
 /.fleet
 /.vscode
 /.ttr.yaml
+/*.drawio

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tango-examples"
 version = "0.2.0"
 edition = "2021"
+autobenches = false
 
 [dependencies]
 tango-bench = { path = "../tango-bench" }
@@ -28,8 +29,10 @@ name = "tango-faster"
 harness = false
 
 [[bench]]
-name = "tango-slower"
+name = "tango-async"
 harness = false
+required-features = ["async-tokio"]
 
 [features]
 align = []
+async-tokio = []

--- a/examples/benches/common.rs
+++ b/examples/benches/common.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "align", feature(fn_align))]
-
 extern crate tango_bench;
 
 use std::{any::type_name, convert::TryFrom, fmt::Debug, iter, marker::PhantomData};

--- a/examples/benches/tango-async.rs
+++ b/examples/benches/tango-async.rs
@@ -1,0 +1,18 @@
+#![cfg_attr(feature = "align", feature(fn_align))]
+
+use crate::test_funcs::factorial;
+use tango_bench::{
+    async_benchmark_fn, asynchronous::tokio::TokioRuntime, tango_benchmarks, tango_main,
+    IntoBenchmarks,
+};
+
+mod test_funcs;
+
+fn num_benchmarks() -> impl IntoBenchmarks {
+    [async_benchmark_fn("factorial_async", TokioRuntime, |b| {
+        b.iter(|| async { factorial(500) })
+    })]
+}
+
+tango_benchmarks!(num_benchmarks());
+tango_main!();

--- a/examples/benches/tango-faster.rs
+++ b/examples/benches/tango-faster.rs
@@ -2,10 +2,7 @@
 
 use crate::test_funcs::{factorial, sum};
 use std::rc::Rc;
-use tango_bench::{
-    async_benchmark_fn, asynchronous::tokio::TokioRuntime, benchmark_fn, tango_benchmarks,
-    tango_main, IntoBenchmarks,
-};
+use tango_bench::{benchmark_fn, tango_benchmarks, tango_main, IntoBenchmarks};
 use test_funcs::{
     create_str_benchmark, sort_unstable, str_count, str_take, vec_benchmarks, IndexedString,
     INPUT_TEXT,
@@ -17,9 +14,6 @@ fn num_benchmarks() -> impl IntoBenchmarks {
     [
         benchmark_fn("sum", |b| b.iter(|| sum(4950))),
         benchmark_fn("factorial", |b| b.iter(|| factorial(495))),
-        async_benchmark_fn("factorial_async", TokioRuntime, |b| {
-            b.iter(|| async { factorial(495) })
-        }),
     ]
 }
 

--- a/examples/benches/tango-faster.rs
+++ b/examples/benches/tango-faster.rs
@@ -2,7 +2,10 @@
 
 use crate::test_funcs::{factorial, sum};
 use std::rc::Rc;
-use tango_bench::{benchmark_fn, tango_benchmarks, tango_main, IntoBenchmarks};
+use tango_bench::{
+    async_benchmark_fn, asynchronous::tokio::TokioRuntime, benchmark_fn, tango_benchmarks,
+    tango_main, IntoBenchmarks,
+};
 use test_funcs::{
     create_str_benchmark, sort_unstable, str_count, str_take, vec_benchmarks, IndexedString,
     INPUT_TEXT,
@@ -14,6 +17,9 @@ fn num_benchmarks() -> impl IntoBenchmarks {
     [
         benchmark_fn("sum", |b| b.iter(|| sum(4950))),
         benchmark_fn("factorial", |b| b.iter(|| factorial(495))),
+        async_benchmark_fn("factorial_async", TokioRuntime, |b| {
+            b.iter(|| async { factorial(495) })
+        }),
     ]
 }
 

--- a/examples/benches/test_funcs.rs
+++ b/examples/benches/test_funcs.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "align", feature(fn_align))]
+
 use rand::{distributions::Standard, rngs::SmallRng, Rng, SeedableRng};
 use std::{hint::black_box, rc::Rc};
 use tango_bench::{benchmark_fn, Benchmark, IntoBenchmarks};

--- a/examples/benches/test_funcs.rs
+++ b/examples/benches/test_funcs.rs
@@ -1,10 +1,9 @@
-#![cfg_attr(feature = "align", feature(fn_align))]
-
 use rand::{distributions::Standard, rngs::SmallRng, Rng, SeedableRng};
 use std::{hint::black_box, rc::Rc};
 use tango_bench::{benchmark_fn, Benchmark, IntoBenchmarks};
 
 /// HTML page with a lot of chinese text to test UTF8 decoding speed
+#[allow(unused)]
 pub const INPUT_TEXT: &str = include_str!("./input.txt");
 
 #[allow(unused)]
@@ -120,6 +119,7 @@ pub fn sort_stable<T: Ord + Copy>(input: &Vec<T>) -> T {
     input[input.len() / 2]
 }
 
+#[allow(unused)]
 pub fn vec_benchmarks(f: impl Fn(&Vec<u64>) -> u64 + Copy + 'static) -> impl IntoBenchmarks {
     let mut benches = vec![];
     for size in [100, 1_000, 10_000, 100_000] {

--- a/tango-bench/Cargo.toml
+++ b/tango-bench/Cargo.toml
@@ -22,6 +22,7 @@ num-traits = "0.2"
 rand = { version = "0.8", features = ["small_rng"] }
 thiserror = "1.0.50"
 alloca = "0.4"
+tokio = { version = "1.37.0", features = ["rt"], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 goblin = "0.7.1"
@@ -30,6 +31,8 @@ tempfile = "3.8"
 
 [features]
 hw-timer = []
+async = []
+async-tokio = ['async', 'dep:tokio']
 
 [[bench]]
 name = "tango"

--- a/tango-bench/benches/tango.rs
+++ b/tango-bench/benches/tango.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "align", feature(fn_align))]
-
 use rand::{distributions::Standard, rngs::SmallRng, Rng, SeedableRng};
 use tango_bench::{
     benchmark_fn, iqr_variance_thresholds, tango_benchmarks, tango_main, IntoBenchmarks, Summary,

--- a/tango-bench/src/dylib.rs
+++ b/tango-bench/src/dylib.rs
@@ -311,7 +311,6 @@ pub mod ffi {
         mem,
         os::raw::c_char,
         ptr::null,
-        usize,
     };
 
     /// Signature types of all FFI API functions

--- a/tango-bench/src/dylib.rs
+++ b/tango-bench/src/dylib.rs
@@ -1,7 +1,7 @@
 //! Loading and resolving symbols from .dylib/.so libraries
 
 use self::ffi::{VTable, SELF_VTABLE};
-use crate::{Benchmark, BenchmarkState, Error};
+use crate::{Benchmark, ErasedSampler, Error};
 use anyhow::Context;
 use libloading::{Library, Symbol};
 use std::{
@@ -256,9 +256,9 @@ enum SpiReply {
 
 /// State which holds the information about list of benchmarks and which one is selected.
 /// Used in FFI API (`tango_*` functions).
-pub struct State {
-    pub benchmarks: Vec<Benchmark>,
-    pub selected_function: Option<(usize, Option<BenchmarkState>)>,
+struct State {
+    benchmarks: Vec<Benchmark>,
+    selected_function: Option<(usize, Option<Box<dyn ErasedSampler>>)>,
 }
 
 impl State {
@@ -273,7 +273,7 @@ impl State {
             .expect("No function was selected. Call tango_select() first")
     }
 
-    fn selected_state_mut(&mut self) -> Option<&mut BenchmarkState> {
+    fn selected_state_mut(&mut self) -> Option<&mut Box<dyn ErasedSampler>> {
         self.selected_function
             .as_mut()
             .and_then(|(_, state)| state.as_mut())
@@ -387,6 +387,7 @@ pub mod ffi {
         if let Some(s) = STATE.as_mut() {
             s.selected_state_mut()
                 .expect("no tango_prepare_state() was called")
+                .as_mut()
                 .estimate_iterations(time_ms) as c_ulonglong
         } else {
             0

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -1,8 +1,15 @@
+#[cfg(feature = "async")]
+pub use asynchronous::async_benchmark_fn;
 use core::ptr;
 use num_traits::ToPrimitive;
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use std::{
-    cmp::Ordering, hint::black_box, io, mem, ops::RangeInclusive, str::Utf8Error, time::Duration,
+    cmp::Ordering,
+    hint::black_box,
+    io, mem,
+    ops::{Deref, RangeInclusive},
+    str::Utf8Error,
+    time::Duration,
 };
 use thiserror::Error;
 use timer::{ActiveTimer, Timer};
@@ -100,107 +107,31 @@ macro_rules! tango_main {
     };
 }
 
-pub struct Bencher {
+pub struct BenchmarkParams {
     pub seed: u64,
 }
 
+pub struct Bencher {
+    params: BenchmarkParams,
+}
+
+impl Deref for Bencher {
+    type Target = BenchmarkParams;
+
+    fn deref(&self) -> &Self::Target {
+        &self.params
+    }
+}
+
 impl Bencher {
-    pub fn iter<O: 'static, F: FnMut() -> O + 'static>(self, func: F) -> Box<dyn Sampler> {
-        Box::new(SimpleSampler { func })
+    pub fn iter<O: 'static, F: FnMut() -> O + 'static>(self, func: F) -> Box<dyn ErasedSampler> {
+        Box::new(Sampler(func))
     }
 }
 
-struct SimpleSampler<F> {
-    func: F,
-}
+struct Sampler<F>(F);
 
-pub trait Sampler {
-    fn measure(&mut self, iterations: usize) -> u64;
-}
-
-impl<O, F: FnMut() -> O> Sampler for SimpleSampler<F> {
-    fn measure(&mut self, iterations: usize) -> u64 {
-        let start = ActiveTimer::start();
-        for _ in 0..iterations {
-            black_box((self.func)());
-        }
-        ActiveTimer::stop(start)
-    }
-}
-
-pub struct Benchmark {
-    name: String,
-    sampler_factory: Box<dyn SamplerFactory>,
-}
-
-pub struct BenchmarkState {
-    sampler: Box<dyn Sampler>,
-}
-
-pub fn benchmark_fn<F: FnMut(Bencher) -> Box<dyn Sampler> + 'static>(
-    name: impl Into<String>,
-    sampler_factory: F,
-) -> Benchmark {
-    let name = name.into();
-    assert!(!name.is_empty());
-    Benchmark {
-        name,
-        sampler_factory: Box::new(SyncSampleFactory(sampler_factory)),
-    }
-}
-
-#[cfg(feature = "async")]
-pub fn async_benchmark_fn<
-    R: asynchronous::AsyncRuntime + 'static,
-    F: FnMut(asynchronous::AsyncBencher<R>) -> Box<dyn Sampler> + 'static,
->(
-    name: impl Into<String>,
-    runtime: R,
-    sampler_factory: F,
-) -> Benchmark {
-    use asynchronous::AsyncSampleFactory;
-
-    let name = name.into();
-    assert!(!name.is_empty());
-    Benchmark {
-        name,
-        sampler_factory: Box::new(AsyncSampleFactory(sampler_factory, runtime)),
-    }
-}
-
-pub trait BenchmarkIteration<T>: FnMut() -> T {}
-impl<T: FnMut() -> O, O> BenchmarkIteration<O> for T {}
-
-pub trait SamplerFactory {
-    fn create_sampler(&mut self, params: Bencher) -> Box<dyn Sampler>;
-}
-
-struct SyncSampleFactory<F>(F);
-
-impl<F: FnMut(Bencher) -> Box<dyn Sampler>> SamplerFactory for SyncSampleFactory<F> {
-    fn create_sampler(&mut self, params: Bencher) -> Box<dyn Sampler> {
-        (self.0)(params)
-    }
-}
-
-impl Benchmark {
-    /// Generates next haystack for the measurement
-    ///
-    /// Calling this method should update internal haystack used for measurement. Returns `true` if update happend,
-    /// `false` if implementation doesn't support haystack generation.
-    /// Haystack/Needle distinction is described in [`Generator`] trait.
-    pub fn prepare_state(&mut self, seed: u64) -> BenchmarkState {
-        let sampler = self.sampler_factory.create_sampler(Bencher { seed });
-        BenchmarkState { sampler }
-    }
-
-    /// Name of the benchmark
-    pub fn name(&self) -> &str {
-        self.name.as_str()
-    }
-}
-
-impl BenchmarkState {
+pub trait ErasedSampler {
     /// Measures the performance if the function
     ///
     /// Returns the cumulative execution time (all iterations) with nanoseconds precision,
@@ -212,9 +143,7 @@ impl BenchmarkState {
     /// to call this method without first calling [`prepare_state()`].
     ///
     /// [`prepare_state()`]: Self::prepare_state()
-    pub fn measure(&mut self, iterations: usize) -> u64 {
-        self.sampler.as_mut().measure(iterations)
-    }
+    fn measure(&mut self, iterations: usize) -> u64;
 
     /// Estimates the number of iterations achievable within given time.
     ///
@@ -222,7 +151,7 @@ impl BenchmarkState {
     /// for implementation to be fast (in the order of 10 ms).
     /// If possible the same input arguments should be used when building the estimate.
     /// If the single call of a function is longer than provided timespan the implementation should return 0.
-    pub fn estimate_iterations(&mut self, time_ms: u32) -> usize {
+    fn estimate_iterations(&mut self, time_ms: u32) -> usize {
         let mut iters = 1;
         let time_ns = Duration::from_millis(time_ms as u64).as_nanos() as u64;
 
@@ -243,6 +172,62 @@ impl BenchmarkState {
         }
 
         iters
+    }
+}
+
+impl<O, F: FnMut() -> O> ErasedSampler for Sampler<F> {
+    fn measure(&mut self, iterations: usize) -> u64 {
+        let start = ActiveTimer::start();
+        for _ in 0..iterations {
+            black_box((self.0)());
+        }
+        ActiveTimer::stop(start)
+    }
+}
+
+pub struct Benchmark {
+    name: String,
+    sampler_factory: Box<dyn SamplerFactory>,
+}
+
+pub fn benchmark_fn<F: FnMut(Bencher) -> Box<dyn ErasedSampler> + 'static>(
+    name: impl Into<String>,
+    sampler_factory: F,
+) -> Benchmark {
+    let name = name.into();
+    assert!(!name.is_empty());
+    Benchmark {
+        name,
+        sampler_factory: Box::new(SyncSampleFactory(sampler_factory)),
+    }
+}
+
+pub trait SamplerFactory {
+    fn create_sampler(&mut self, params: BenchmarkParams) -> Box<dyn ErasedSampler>;
+}
+
+struct SyncSampleFactory<F>(F);
+
+impl<F: FnMut(Bencher) -> Box<dyn ErasedSampler>> SamplerFactory for SyncSampleFactory<F> {
+    fn create_sampler(&mut self, params: BenchmarkParams) -> Box<dyn ErasedSampler> {
+        (self.0)(Bencher { params })
+    }
+}
+
+impl Benchmark {
+    /// Generates next haystack for the measurement
+    ///
+    /// Calling this method should update internal haystack used for measurement. Returns `true` if update happend,
+    /// `false` if implementation doesn't support haystack generation.
+    /// Haystack/Needle distinction is described in [`Generator`] trait.
+    pub fn prepare_state(&mut self, seed: u64) -> Box<dyn ErasedSampler> {
+        self.sampler_factory
+            .create_sampler(BenchmarkParams { seed })
+    }
+
+    /// Name of the benchmark
+    pub fn name(&self) -> &str {
+        self.name.as_str()
     }
 }
 
@@ -791,36 +776,60 @@ mod timer {
 
 #[cfg(feature = "async")]
 pub mod asynchronous {
-    use super::{Bencher, Sampler, SamplerFactory, SimpleSampler};
-    use std::future::Future;
+    use super::{Benchmark, BenchmarkParams, ErasedSampler, Sampler, SamplerFactory};
+    use std::{future::Future, ops::Deref};
+
+    pub fn async_benchmark_fn<R, F>(
+        name: impl Into<String>,
+        runtime: R,
+        sampler_factory: F,
+    ) -> Benchmark
+    where
+        R: AsyncRuntime + 'static,
+        F: FnMut(AsyncBencher<R>) -> Box<dyn ErasedSampler> + 'static,
+    {
+        let name = name.into();
+        assert!(!name.is_empty());
+        Benchmark {
+            name,
+            sampler_factory: Box::new(AsyncSampleFactory(sampler_factory, runtime)),
+        }
+    }
 
     pub struct AsyncSampleFactory<F, R>(pub F, pub R);
 
-    impl<R: AsyncRuntime, F: FnMut(AsyncBencher<R>) -> Box<dyn Sampler>> SamplerFactory
+    impl<R: AsyncRuntime, F: FnMut(AsyncBencher<R>) -> Box<dyn ErasedSampler>> SamplerFactory
         for AsyncSampleFactory<F, R>
     {
-        fn create_sampler(&mut self, params: Bencher) -> Box<dyn Sampler> {
+        fn create_sampler(&mut self, params: BenchmarkParams) -> Box<dyn ErasedSampler> {
             (self.0)(AsyncBencher {
-                bencher: params,
+                params,
                 runtime: self.1,
             })
         }
     }
 
     pub struct AsyncBencher<R> {
-        pub(super) bencher: Bencher,
-        pub(super) runtime: R,
+        params: BenchmarkParams,
+        runtime: R,
     }
 
     impl<R: AsyncRuntime + 'static> AsyncBencher<R> {
-        pub fn iter<O, Fut, F>(self, func: F) -> Box<dyn Sampler>
+        pub fn iter<O, Fut, F>(self, func: F) -> Box<dyn ErasedSampler>
         where
             O: 'static,
             Fut: Future<Output = O>,
-            F: FnMut() -> Fut + 'static + Copy,
+            F: FnMut() -> Fut + Copy + 'static,
         {
-            let f = move || self.runtime.block_on(func);
-            Box::new(SimpleSampler { func: f })
+            Box::new(Sampler(move || self.runtime.block_on(func)))
+        }
+    }
+
+    impl<R> Deref for AsyncBencher<R> {
+        type Target = BenchmarkParams;
+
+        fn deref(&self) -> &Self::Target {
+            &self.params
         }
     }
 


### PR DESCRIPTION
This PR added tokio support and ability to test async functions (eg.):

```rust
fn num_benchmarks() -> impl IntoBenchmarks {
    [
        async_benchmark_fn("factorial_async", TokioRuntime, |b| {
            b.iter(|| async { factorial(495) })
        }),
    ]
}

```