### PR TITLE
Add typos integration

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,9 +10,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: "clippy, rustfmt"
+      - uses: olix0r/cargo-action-fmt/setup@v2
       - uses: Swatinem/rust-cache@v2
       - name: Running clippy
-        run: cargo clippy --all-targets --all-features -p tango-bench -- -D warnings
+        run: cargo clippy --all-targets --all-features -p tango-bench --message-format=json | cargo-action-fmt
       - name: Checking formatting
         run: cargo fmt -- --check --color always
       - name: Typo

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,15 +11,12 @@ jobs:
         with:
           components: "clippy, rustfmt"
       - uses: Swatinem/rust-cache@v2
-      - name: Checking formatting
-        run: cargo fmt -- --check --color always
-        continue-on-error: true
       - name: Running clippy
         run: cargo clippy --all-targets --all-features -p tango-bench -- -D warnings
-        continue-on-error: true
+      - name: Checking formatting
+        run: cargo fmt -- --check --color always
       - name: Typo
         uses: crate-ci/typos@master
-        continue-on-error: true
   test:
     strategy:
       matrix:
@@ -37,7 +34,7 @@ jobs:
         run: cargo test
 
   bench:
-    needs: [test, lint]
+    needs: [test]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,10 +13,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Checking formatting
         run: cargo fmt -- --check --color always
+        continue-on-error: true
       - name: Running clippy
-        run: cargo clippy --all-targets --all-features -p tango-bench
+        run: cargo clippy --all-targets --all-features -p tango-bench -- -D warnings
+        continue-on-error: true
       - name: Typo
         uses: crate-ci/typos@master
+        continue-on-error: true
   test:
     strategy:
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,8 @@ jobs:
         run: cargo fmt -- --check --color always
       - name: Running clippy
         run: cargo clippy --all-targets --all-features -p tango-bench
+      - name: Typo
+        uses: crate-ci/typos@master
   test:
     strategy:
       matrix:

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,2 @@
+[files]
+extend-exclude = ["examples/benches/input.txt", "notebooks/*.ipynb"]

--- a/examples/benches/common.rs
+++ b/examples/benches/common.rs
@@ -117,7 +117,7 @@ where
 }
 
 pub const SETTINGS: MeasurementSettings = MeasurementSettings {
-    samples_per_haystack: usize::max_value(),
+    samples_per_haystack: usize::MAX,
     max_iterations_per_sample: 10_000,
     ..DEFAULT_SETTINGS
 };

--- a/examples/benches/search-vec.rs
+++ b/examples/benches/search-vec.rs
@@ -7,6 +7,7 @@ mod common;
 
 #[cfg_attr(feature = "align", repr(align(32)))]
 #[cfg_attr(feature = "align", inline(never))]
+#[allow(clippy::ptr_arg)]
 fn search_vec<T: Copy + Ord>(haystack: &Vec<T>, needle: T) -> Option<T> {
     haystack
         .binary_search(&needle)

--- a/examples/benches/test_funcs.rs
+++ b/examples/benches/test_funcs.rs
@@ -36,12 +36,12 @@ impl From<&str> for IndexedString {
     fn from(value: &str) -> Self {
         Self {
             string: value.to_owned(),
-            indices: build_char_indicies(value),
+            indices: build_char_indices(value),
         }
     }
 }
 
-pub fn build_char_indicies(text: &str) -> Vec<usize> {
+fn build_char_indices(text: &str) -> Vec<usize> {
     text.char_indices().map(|(idx, _)| idx).collect()
 }
 

--- a/examples/benches/test_funcs.rs
+++ b/examples/benches/test_funcs.rs
@@ -103,6 +103,7 @@ pub fn str_take(n: usize, s: &str) -> usize {
 #[cfg_attr(feature = "align", repr(align(32)))]
 #[cfg_attr(feature = "align", inline(never))]
 #[allow(unused)]
+#[allow(clippy::ptr_arg)]
 pub fn sort_unstable<T: Ord + Copy>(input: &Vec<T>) -> T {
     let mut input = input.clone();
     input.sort_unstable();
@@ -112,6 +113,7 @@ pub fn sort_unstable<T: Ord + Copy>(input: &Vec<T>) -> T {
 #[cfg_attr(feature = "align", repr(align(32)))]
 #[cfg_attr(feature = "align", inline(never))]
 #[allow(unused)]
+#[allow(clippy::ptr_arg)]
 pub fn sort_stable<T: Ord + Copy>(input: &Vec<T>) -> T {
     let mut input = input.clone();
     input.sort();

--- a/tango-bench/src/cli.rs
+++ b/tango-bench/src/cli.rs
@@ -37,7 +37,7 @@ enum BenchmarkMode {
         #[command(flatten)]
         bench_flags: CargoBenchFlags,
 
-        /// Path to the executable to test agains. Tango will test agains itself if no executable given
+        /// Path to the executable to test against. Tango will test against itself if no executable given
         path: Option<PathBuf>,
 
         /// write CSV dumps of all the measurements in a given location

--- a/tango-bench/src/dylib.rs
+++ b/tango-bench/src/dylib.rs
@@ -301,7 +301,7 @@ pub fn __tango_init(benchmarks: Vec<Benchmark>) {
 /// Defines all the foundation types and exported symbols for the FFI communication API between two
 /// executables.
 ///
-/// Tango execution model implies simultaneous exectution of the code from two binaries. To achive that
+/// Tango execution model implies simultaneous execution of the code from two binaries. To achive that
 /// Tango benchmark is compiled in a way that executable is also a shared library (.dll, .so, .dylib). This
 /// way two executables can coexist in the single process at the same time.
 pub mod ffi {
@@ -324,7 +324,7 @@ pub mod ffi {
     type FreeFn = unsafe extern "C" fn();
 
     /// This block of constants is checking that all exported tango functions are of valid type according to the API.
-    /// Those constants are not ment to be used at runtime in any way
+    /// Those constants are not meant to be used at runtime in any way
     #[allow(unused)]
     mod type_check {
         use super::*;
@@ -424,7 +424,7 @@ pub mod ffi {
     ///
     /// Used to communicate with FFI API of the executable bypassing dynamic linking.
     /// # Safety
-    /// Instances of this type should not be created directory. The single instance [`SELF_SPI`] shoud be used instead
+    /// Instances of this type should not be created directory. The single instance [`SELF_SPI`] should be used instead
     pub(super) struct SelfVTable;
 
     impl VTable for SelfVTable {

--- a/tango-bench/src/dylib.rs
+++ b/tango-bench/src/dylib.rs
@@ -301,7 +301,7 @@ pub fn __tango_init(benchmarks: Vec<Benchmark>) {
 /// Defines all the foundation types and exported symbols for the FFI communication API between two
 /// executables.
 ///
-/// Tango execution model implies simultaneous execution of the code from two binaries. To achive that
+/// Tango execution model implies simultaneous execution of the code from two binaries. To achieve that
 /// Tango benchmark is compiled in a way that executable is also a shared library (.dll, .so, .dylib). This
 /// way two executables can coexist in the single process at the same time.
 pub mod ffi {

--- a/tango-bench/src/dylib.rs
+++ b/tango-bench/src/dylib.rs
@@ -552,10 +552,10 @@ pub mod ffi {
         name: &'static str,
     ) -> Result<Symbol<'static, T>, Error> {
         unsafe {
-            let symbol: Symbol<'l, T> = library
+            let symbol = library
                 .get(name.as_bytes())
                 .map_err(Error::UnableToLoadSymbol)?;
-            Ok(mem::transmute(symbol))
+            Ok(mem::transmute::<Symbol<'l, T>, Symbol<'static, T>>(symbol))
         }
     }
 }

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -651,6 +651,8 @@ where
             0.
         };
 
+        1 / 1;
+
         Some(Summary {
             n: self.n,
             min: self.min,

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -651,8 +651,6 @@ where
             0.
         };
 
-        let a = 1. / 2.;
-
         Some(Summary {
             n: self.n,
             min: self.min,

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -651,7 +651,7 @@ where
             0.
         };
 
-        1 / 1;
+        let a = 1. / 2.;
 
         Some(Summary {
             n: self.n,

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -356,7 +356,7 @@ impl Default for MeasurementSettings {
 trait SampleLength {
     /// Returns the number of iterations to run for the next sample
     ///
-    /// Accepts the number of iteration being run starting from 0 and cummulative time spent by both functions
+    /// Accepts the number of iteration being run starting from 0 and cumulative time spent by both functions
     fn next_sample_iterations(&mut self, iteration_no: usize, estimate: usize) -> usize;
 }
 
@@ -471,7 +471,7 @@ pub(crate) fn calculate_run_result<N: Into<String>>(
         .map(|(&v, &iters)| (v as f64) / (iters as f64))
         .collect::<Vec<_>>();
 
-    // Calculating measurements range. All measurements outside this interval concidered outliers
+    // Calculating measurements range. All measurements outside this interval considered outliers
     let range = if filter_outliers {
         iqr_variance_thresholds(diff.to_vec())
     } else {
@@ -680,7 +680,7 @@ pub fn iqr_variance_thresholds(mut input: Vec<f64>) -> Option<RangeInclusive<f64
     let low_threshold = input[q1] - iqr * 1.5;
     let high_threshold = input[q3] + iqr * 1.5;
 
-    // Calculating the indicies of the thresholds in an dataset
+    // Calculating the indices of the thresholds in an dataset
     let low_threshold_idx =
         match input[0..q1].binary_search_by(|probe| probe.total_cmp(&low_threshold)) {
             Ok(idx) => idx,
@@ -709,7 +709,7 @@ mod timer {
     #[cfg(all(feature = "hw-timer", target_arch = "x86_64"))]
     pub(super) type ActiveTimer = x86::RdtscpTimer;
 
-    #[cfg(not(feature = "hw-timer"))]
+    #[cfg(not(all(feature = "hw-timer", target_arch = "x86_64")))]
     pub(super) type ActiveTimer = PlatformTimer;
 
     pub(super) trait Timer<T> {
@@ -783,7 +783,7 @@ mod tests {
 
         // Generate 20 random values in range [-50, 50]
         // and add 10 outliers in each of two ranges [-1000, -200] and [200, 1000]
-        // This way IQR is no more than 100 and thresholds should be withing [-50, 50] range
+        // This way IQR is no more than 100 and thresholds should be within [-50, 50] range
         let mut values = vec![];
         values.extend((0..20).map(|_| rng.gen_range(-50.0..=50.)));
         values.extend((0..10).map(|_| rng.gen_range(-1000.0..=-200.0)));

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -825,7 +825,7 @@ mod tests {
             let stat = Summary::from(&values).unwrap();
 
             let sum = (i * (i + 1)) as f64 / 2.;
-            let expected_mean = sum as f64 / i as f64;
+            let expected_mean = sum / i as f64;
             let expected_variance = naive_variance(values.as_slice());
 
             assert_eq!(stat.min, 1);
@@ -923,7 +923,7 @@ mod tests {
         let n = values.len() as f64;
         let mean = f64::from(values.iter().copied().sum::<T>()) / n;
         let mut sum_of_squares = 0.;
-        for value in values.into_iter().copied() {
+        for value in values.iter().copied() {
             sum_of_squares += (f64::from(value) - mean).powi(2);
         }
         sum_of_squares / (n - 1.)

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -163,7 +163,7 @@ impl<T: FnMut(Bencher) -> Box<dyn Sampler>> SamplerFactory for T {}
 impl Benchmark {
     /// Generates next haystack for the measurement
     ///
-    /// Calling this method should update internal haystack used for measurement. Returns `true` if update happend,
+    /// Calling this method should update internal haystack used for measurement. Returns `true` when update happens,
     /// `false` if implementation doesn't support haystack generation.
     /// Haystack/Needle distinction is described in [`Generator`] trait.
     pub fn prepare_state(&mut self, seed: u64) -> BenchmarkState {

--- a/tango-bench/src/linux.rs
+++ b/tango-bench/src/linux.rs
@@ -46,7 +46,7 @@ pub enum Error {
 /// From 2.29 [dynamic loader throws an error](glibc) if `DF_1_PIE` flag is set in
 /// `DT_FLAG_1` tag on the `PT_DYNAMIC` section. Although the loading of executable
 /// files as a shared library was never an intended use case, through the years
-/// some applications adopted this technique and it is very convinient in the context
+/// some applications adopted this technique and it is very convenient in the context
 /// of paired benchmarking.
 ///
 /// Following method check if this flag is set and patch binary at runtime


### PR DESCRIPTION
- typo integrated
- `cargo-actions-fmt` integrated for `clippy`
- all clippy warnings are fixed
- all typos are fixed