### PR TITLE
Safe FFI boundary

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -37,6 +37,10 @@ name = "tango-async"
 harness = false
 required-features = ["async-tokio"]
 
+[[bench]]
+name = "panicking"
+harness = false
+
 [features]
 prefetch = ["ordsearch/nightly"]
 align = []

--- a/examples/benches/panicking.rs
+++ b/examples/benches/panicking.rs
@@ -1,0 +1,4 @@
+use tango_bench::{benchmark_fn, tango_benchmarks, tango_main};
+
+tango_benchmarks!([benchmark_fn("panicking", |_| panic!("Ooops"))]);
+tango_main!();

--- a/tango-bench/src/cli.rs
+++ b/tango-bench/src/cli.rs
@@ -338,11 +338,8 @@ mod solo_test {
 
         let seed = seed.unwrap_or_else(rand::random);
 
-        spi_func.spi.prepare_state(seed).map_err(Error::FFIError)?;
-        let iters = spi_func
-            .spi
-            .estimate_iterations(TIME_SLICE_MS)
-            .map_err(Error::FFIError)?;
+        spi_func.spi.prepare_state(seed)?;
+        let iters = spi_func.spi.estimate_iterations(TIME_SLICE_MS)?;
         let mut iterations_per_sample = (iters / 2).max(1);
         let mut sampler = create_sampler(&settings, seed);
 
@@ -603,18 +600,12 @@ mod paired_test {
 
         let seed = seed.unwrap_or_else(rand::random);
 
-        a_func.spi.prepare_state(seed).map_err(Error::FFIError)?;
-        let a_iters = a_func
-            .spi
-            .estimate_iterations(TIME_SLICE_MS)
-            .map_err(Error::FFIError)?;
+        a_func.spi.prepare_state(seed)?;
+        let a_iters = a_func.spi.estimate_iterations(TIME_SLICE_MS)?;
         let a_estimate = (a_iters / 2).max(1);
 
-        b_func.spi.prepare_state(seed).map_err(Error::FFIError)?;
-        let b_iters = b_func
-            .spi
-            .estimate_iterations(TIME_SLICE_MS)
-            .map_err(Error::FFIError)?;
+        b_func.spi.prepare_state(seed)?;
+        let b_iters = b_func.spi.estimate_iterations(TIME_SLICE_MS)?;
         let b_estimate = (b_iters / 2).max(1);
 
         let mut iterations_per_sample = a_estimate.min(b_estimate);
@@ -924,7 +915,7 @@ fn prepare_func(
     firewall: Option<&CacheFirewall>,
 ) -> Result<()> {
     if let Some(seed) = prepare_state_seed {
-        f.spi.prepare_state(seed).map_err(Error::FFIError)?;
+        f.spi.prepare_state(seed)?;
         if let Some(firewall) = firewall {
             firewall.issue_read();
         }

--- a/tango-bench/src/cli.rs
+++ b/tango-bench/src/cli.rs
@@ -463,7 +463,7 @@ mod paired_test {
         };
 
         let mut spi_self = Spi::for_self(mode).ok_or(Error::SpiSelfWasMoved)?;
-        let mut spi_lib = Spi::for_library(path, mode);
+        let mut spi_lib = Spi::for_library(path, mode)?;
 
         settings.filter_outliers = filter_outliers;
         settings.cache_firewall = cache_firewall;

--- a/tango-bench/src/cli.rs
+++ b/tango-bench/src/cli.rs
@@ -463,7 +463,8 @@ mod paired_test {
         };
 
         let mut spi_self = Spi::for_self(mode).ok_or(Error::SpiSelfWasMoved)?;
-        let mut spi_lib = Spi::for_library(path, mode)?;
+        let mut spi_lib = Spi::for_library(&path, mode)
+            .with_context(|| format!("Unable to load library: {}", path.display()))?;
 
         settings.filter_outliers = filter_outliers;
         settings.cache_firewall = cache_firewall;

--- a/tango-bench/src/cli.rs
+++ b/tango-bench/src/cli.rs
@@ -601,12 +601,24 @@ mod paired_test {
 
         let seed = seed.unwrap_or_else(rand::random);
 
-        a_func.spi.prepare_state(seed)?;
-        let a_iters = a_func.spi.estimate_iterations(TIME_SLICE_MS)?;
+        a_func
+            .spi
+            .prepare_state(seed)
+            .context("Unable to prepare benchmark state")?;
+        let a_iters = a_func
+            .spi
+            .estimate_iterations(TIME_SLICE_MS)
+            .context("Failed to estimate required iterations number")?;
         let a_estimate = (a_iters / 2).max(1);
 
-        b_func.spi.prepare_state(seed)?;
-        let b_iters = b_func.spi.estimate_iterations(TIME_SLICE_MS)?;
+        b_func
+            .spi
+            .prepare_state(seed)
+            .context("Unable to prepare benchmark state")?;
+        let b_iters = b_func
+            .spi
+            .estimate_iterations(TIME_SLICE_MS)
+            .context("Failed to estimate required iterations number")?;
         let b_estimate = (b_iters / 2).max(1);
 
         let mut iterations_per_sample = a_estimate.min(b_estimate);

--- a/tango-bench/src/dylib.rs
+++ b/tango-bench/src/dylib.rs
@@ -497,34 +497,20 @@ pub mod ffi {
     }
 
     impl VTable {
-        pub(super) fn new(library: Library) -> Result<Self, Error> {
+        pub(super) fn new(lib: Library) -> Result<Self, Error> {
             // SAFETY: library is boxed and not moved here, therefore we can safley construct self-referential
             // struct here
-            let library = Box::new(library);
-            let init_fn = *lookup_symbol::<InitFn>(&library, "tango_init")?;
-            let count_fn = *lookup_symbol::<CountFn>(&library, "tango_count")?;
-            let select_fn = *lookup_symbol::<SelectFn>(&library, "tango_select")?;
-            let get_test_name_fn =
-                *lookup_symbol::<GetTestNameFn>(&library, "tango_get_test_name")?;
-            let run_fn = *lookup_symbol::<RunFn>(&library, "tango_run")?;
-            let estimate_iterations_fn =
-                *lookup_symbol::<EstimateIterationsFn>(&library, "tango_estimate_iterations")?;
-            let prepare_state_fn =
-                *lookup_symbol::<PrepareStateFn>(&library, "tango_prepare_state")?;
-            let get_last_error_fn =
-                *lookup_symbol::<GetLastErrorFn>(&library, "tango_get_last_error")?;
-            let free_fn = *lookup_symbol::<FreeFn>(&library, "tango_free")?;
             Ok(Self {
-                init_fn,
-                count_fn,
-                select_fn,
-                get_test_name_fn,
-                run_fn,
-                estimate_iterations_fn,
-                prepare_state_fn,
-                get_last_error_fn,
-                free_fn,
-                _library: Some(library),
+                init_fn: *lookup_symbol(&lib, "tango_init")?,
+                count_fn: *lookup_symbol(&lib, "tango_count")?,
+                select_fn: *lookup_symbol(&lib, "tango_select")?,
+                get_test_name_fn: *lookup_symbol(&lib, "tango_get_test_name")?,
+                run_fn: *lookup_symbol(&lib, "tango_run")?,
+                estimate_iterations_fn: *lookup_symbol(&lib, "tango_estimate_iterations")?,
+                prepare_state_fn: *lookup_symbol(&lib, "tango_prepare_state")?,
+                get_last_error_fn: *lookup_symbol(&lib, "tango_get_last_error")?,
+                free_fn: *lookup_symbol(&lib, "tango_free")?,
+                _library: Some(Box::new(lib)),
             })
         }
 
@@ -601,10 +587,7 @@ pub mod ffi {
         }
     }
 
-    fn lookup_symbol<'l, T>(
-        library: &'l Library,
-        name: &'static str,
-    ) -> Result<Symbol<'l, T>, Error> {
+    fn lookup_symbol<'l, T>(library: &'l Library, name: &str) -> Result<Symbol<'l, T>, Error> {
         unsafe {
             library
                 .get(name.as_bytes())

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "async")]
 pub use asynchronous::async_benchmark_fn;
 use core::ptr;
+use dylib::ffi::TANGO_API_VERSION;
 use num_traits::ToPrimitive;
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use std::{
@@ -51,6 +52,12 @@ pub enum Error {
 
     #[error("Unknown FFI Error")]
     UnknownFFIError,
+
+    #[error(
+        "Non matching tango version. Expected: {}, got: {0}",
+        TANGO_API_VERSION
+    )]
+    IncorrectVersion(u32),
 }
 
 /// Registers benchmark in the system

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -41,6 +41,9 @@ pub enum Error {
 
     #[error("IO Error")]
     IOError(#[from] io::Error),
+
+    #[error("FFI Error")]
+    FFIError(String),
 }
 
 /// Registers benchmark in the system

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -44,6 +44,9 @@ pub enum Error {
 
     #[error("FFI Error: {0}")]
     FFIError(String),
+
+    #[error("Unknown FFI Error")]
+    UnknownFFIError,
 }
 
 /// Registers benchmark in the system

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -42,7 +42,7 @@ pub enum Error {
     #[error("IO Error")]
     IOError(#[from] io::Error),
 
-    #[error("FFI Error")]
+    #[error("FFI Error: {0}")]
     FFIError(String),
 }
 

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -8,6 +8,7 @@ use std::{
     hint::black_box,
     io, mem,
     ops::{Deref, RangeInclusive},
+    path::PathBuf,
     str::Utf8Error,
     time::Duration,
 };
@@ -29,6 +30,9 @@ pub enum Error {
 
     #[error("Spi::self() was already called")]
     SpiSelfWasMoved,
+
+    #[error("Unable to load library {0}. Error: {1}")]
+    UnableToLoadLibrary(PathBuf, libloading::Error),
 
     #[error("Unable to load library symbol")]
     UnableToLoadSymbol(#[source] libloading::Error),


### PR DESCRIPTION
Fixes #40 

Plan:

- [x] `tango_prepare_state`/`tango_run`/`tango_estimate_iterations` should return boolean
- [ ] ~~add separate function to read measurements~~
- [x] add separate function to read last error
- [x] test should be stopped after first panic
- [x] add support of protocol version checking