### PR TITLE
Using macOS 13 in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-          - os: macos-12
+          - os: macos-13
           - os: windows-2019
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
macOS 12 is deprecated by GitHub CI