### PR TITLE
Tokio time

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ To use Tango.rs in an asynchronous setup, follow these steps:
     harness = false
     ```
 
+    If you need Tokio's timer functionalities (e.g., for `tokio::time::sleep`), you can enable the `async-tokio-time` feature:
+
+    ```toml
+    [dev-dependencies]
+    tango-bench = { version = "0.6", features = ["async-tokio-time"] }
+    ```
+
 2. Create `benches/async_factorial.rs` with the following content:
 
     ```rust,no_run

--- a/tango-bench/Cargo.toml
+++ b/tango-bench/Cargo.toml
@@ -33,6 +33,7 @@ tempfile = "3.8"
 hw-timer = []
 async = []
 async-tokio = ['async', 'dep:tokio']
+async-tokio-time = ["async-tokio", "tokio/time"]
 
 [[bench]]
 name = "tango"

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -838,12 +838,15 @@ pub mod asynchronous {
         use super::*;
         use ::tokio::runtime::Builder;
 
-        #[derive(Copy, Clone)]
+        #[derive(Copy, Clone, Default)]
         pub struct TokioRuntime;
 
         impl AsyncRuntime for TokioRuntime {
             fn block_on<O, Fut: Future<Output = O>, F: FnMut() -> Fut>(&self, mut f: F) -> O {
-                let runtime = Builder::new_current_thread().build().unwrap();
+                let mut builder = Builder::new_current_thread();
+                #[cfg(feature = "async-tokio-time")]
+                builder.enable_time();
+                let runtime = builder.build().unwrap();
                 runtime.block_on(f())
             }
         }


### PR DESCRIPTION
**Enable Tokio Timers via `async-tokio-time` Feature**

**Description:**

This PR introduces a new feature flag, `async-tokio-time`, to the `tango-bench` crate. When this feature is enabled alongside `async-tokio`, the Tokio runtime instantiated by `tango_bench::asynchronous::tokio::TokioRuntime` will be configured with timers enabled (using `Builder::enable_time()`).

**Motivation:**

Currently, the default Tokio runtime used for `async-tokio` benchmarks is minimal and does not have the time driver enabled. This causes issues with crates like `sqlx` (and potentially others) that rely on Tokio timers for operations such as connection pooling, timeouts, or other scheduled tasks. When these crates attempt to use timer-based functions, they panic with an error similar to:
`A Tokio 1.x context was found, but timers are disabled. Call enable_time on the runtime builder to enable timers.`

This PR addresses this by providing a mechanism to explicitly enable timers for the Tokio runtime managed by `tango-bench`.

**Changes:**

*   Added a new feature `async-tokio-time` to `tango-bench/Cargo.toml`.
*   Modified `tango-bench/src/asynchronous.rs` within the `tokio` module:
    *   The `TokioRuntime::block_on` method now conditionally calls `.enable_time()` on the `tokio::runtime::Builder` if the `async-tokio-time` feature is active.
    *   (Alternatively, if you made it `.enable_all()`, mention that instead and briefly justify why `enable_all` was chosen over just `enable_time` - e.g., for broader compatibility or if IO was also implicitly needed by some async setup).

**Usage:**

Users who require Tokio timers for their asynchronous benchmarks can now enable it in their project's `Cargo.toml`:

```toml
[dev-dependencies]
tango-bench = { version = "0.6", features = ["async-tokio", "async-tokio-time"] }
```

**Benefits:**

*   Allows benchmarking of asynchronous code that depends on Tokio's time facilities.
*   Improves compatibility with popular async ecosystem crates like `sqlx`.
*   Maintains the minimal runtime by default for users who do not need timers, and provides an explicit opt-in for those who do. 