### PR TITLE
Enable all Tokio drivers for async benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Tango is designed to have the capability to detect a 1% change in performance wi
 
    ```toml
    [dev-dependencies]
-   tango-bench = "0.5"
+   tango-bench = "0.6"
 
    [[bench]]
    name = "factorial"
@@ -119,7 +119,7 @@ To use Tango.rs in an asynchronous setup, follow these steps:
 
     ```toml
     [dev-dependencies]
-    tango-bench = { version = "0.5", features = ["async-tokio"] }
+    tango-bench = { version = "0.6", features = ["async-tokio"] }
 
     [[bench]]
     name = "async_factorial"

--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ To use Tango.rs in an asynchronous setup, follow these steps:
     harness = false
     ```
 
-    If you need Tokio's timer functionalities (e.g., for `tokio::time::sleep`), you can enable the `async-tokio-time` feature:
+    If you need Tokio's timer functionalities (e.g., for `tokio::time::sleep`), you can enable the `async-tokio-all-drivers` feature:
 
     ```toml
     [dev-dependencies]
-    tango-bench = { version = "0.6", features = ["async-tokio-time"] }
+    tango-bench = { version = "0.6", features = ["async-tokio-all-drivers"] }
     ```
 
 2. Create `benches/async_factorial.rs` with the following content:

--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ To use Tango.rs in an asynchronous setup, follow these steps:
     harness = false
     ```
 
+    If you need Tokio's timer functionalities (e.g., for `tokio::time::sleep`), you can enable the `async-tokio-time` feature:
+
+    ```toml
+    [dev-dependencies]
+    tango-bench = { version = "0.6", features = ["async-tokio-time"] }
+    ```
+
 2. Create `benches/async_factorial.rs` with the following content:
 
     ```rust,no_run

--- a/tango-bench/Cargo.toml
+++ b/tango-bench/Cargo.toml
@@ -33,7 +33,7 @@ tempfile = "3.8"
 hw-timer = []
 async = []
 async-tokio = ['async', 'dep:tokio']
-async-tokio-time = ["async-tokio", "tokio/time"]
+async-tokio-all-drivers = ["async-tokio", "tokio/time"]
 
 [[bench]]
 name = "tango"

--- a/tango-bench/Cargo.toml
+++ b/tango-bench/Cargo.toml
@@ -32,8 +32,8 @@ tempfile = "3.8"
 [features]
 hw-timer = []
 async = []
-async-tokio = ['async', 'dep:tokio']
-async-tokio-all-drivers = ["async-tokio", "tokio/time"]
+async-tokio = ["async", "dep:tokio"]
+async-tokio-all-drivers = ["async-tokio", "tokio/full"]
 
 [[bench]]
 name = "tango"

--- a/tango-bench/Cargo.toml
+++ b/tango-bench/Cargo.toml
@@ -33,6 +33,7 @@ tempfile = "3.8"
 hw-timer = []
 async = []
 async-tokio = ['async', 'dep:tokio']
+async-tokio-time = ["async-tokio", "tokio/time"]
 
 [[bench]]
 name = "tango"

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -844,8 +844,8 @@ pub mod asynchronous {
         impl AsyncRuntime for TokioRuntime {
             fn block_on<O, Fut: Future<Output = O>, F: FnMut() -> Fut>(&self, mut f: F) -> O {
                 let mut builder = Builder::new_current_thread();
-                #[cfg(feature = "async-tokio-time")]
-                builder.enable_time();
+                #[cfg(feature = "async-tokio-all-drivers")]
+                builder.enable_all();
                 let runtime = builder.build().unwrap();
                 runtime.block_on(f())
             }

--- a/tango-bench/src/lib.rs
+++ b/tango-bench/src/lib.rs
@@ -838,12 +838,15 @@ pub mod asynchronous {
         use super::*;
         use ::tokio::runtime::Builder;
 
-        #[derive(Copy, Clone)]
+        #[derive(Copy, Clone, Default)]
         pub struct TokioRuntime;
 
         impl AsyncRuntime for TokioRuntime {
             fn block_on<O, Fut: Future<Output = O>, F: FnMut() -> Fut>(&self, mut f: F) -> O {
-                let runtime = Builder::new_current_thread().build().unwrap();
+                let mut builder = Builder::new_current_thread();
+                #[cfg(feature = "async-tokio-time")]
+                builder.enable_time();
+                let runtime = builder.build().unwrap();
                 runtime.block_on(f())
             }
         }


### PR DESCRIPTION
##  Enable All Tokio Drivers via async-tokio-all-drivers Feature
### Description:
This PR introduces a new feature flag, async-tokio-all-drivers, to the tango-bench crate. When this feature is enabled alongside async-tokio, the Tokio runtime instantiated by tango_bench::asynchronous::tokio::TokioRuntime will be configured with all drivers enabled (using Builder::enable_all()).
### Motivation:
Currently, the default Tokio runtime used for async-tokio benchmarks is minimal and does not have the time or I/O drivers enabled. This causes issues with crates that rely on Tokio timers (e.g., sqlx for connection pooling, timeouts) or Tokio I/O facilities (e.g., for asynchronous file operations, network calls within the benchmark setup or teardown). When these crates attempt to use driver-dependent functions, they panic with errors similar to:
```
A Tokio 1.x context was found, but timers are disabled. Call enable_time on the runtime builder to enable timers.
A Tokio 1.x context was found, but IO is disabled. Call enable_io on the runtime builder to enable IO.
```
This PR addresses this by providing a mechanism to explicitly enable all standard drivers for the Tokio runtime managed by tango-bench.
### Changes:
Added a new feature `async-tokio-all-drivers` to `tango-bench/Cargo.toml`.
Modified `tango-bench/src/asynchronous.rs` within the tokio module:
The `TokioRuntime::block_on` method now conditionally calls `.enable_all()` on the `tokio::runtime::Builder` if the `async-tokio-all-drivers` feature is active. The `enable_all()` method was chosen to provide the broadest compatibility out-of-the-box for benchmarks involving various async operations, simplifying the configuration for users who might need both time and I/O drivers.
### Usage:
Users who require Tokio's time and/or I/O drivers for their asynchronous benchmarks can now enable them in their project's `Cargo.toml`:
```
[dev-dependencies]
tango-bench = { version = "0.6", features = ["async-tokio-all-drivers"] }
```
### Benefits:
Allows benchmarking of asynchronous code that depends on Tokio's time and I/O facilities.
Improves compatibility with a wider range of async ecosystem crates.
Maintains the minimal runtime by default for users who do not need extra drivers, providing an explicit opt-in for those who require the full runtime capabilities.